### PR TITLE
fix: Fixed the SecDim and Ethereum Links under Training

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,13 +101,13 @@
 # Trainings
 
 * [SEC554: Blockchain and Smart Contract Security](https://www.sans.org/cyber-security-courses/blockchain-smart-contract-security/)
-* [SecDim](https://www.sans.org/cyber-security-courses/blockchain-smart-contract-security/)
-* [Ethereum Smart Contract Security](https://secdim.com)
+* [SecDim](https://secdim.com)
+* [Ethereum Smart Contract Security](https://academy.moralis.io/courses/ethereum-smart-contract-security)
 * [Solidity, Blockchain, and Smart Contract Course ](https://www.youtube.com/watch?v=M576WGiDBdQ)
-
 * [Smart Contract Security 101](https://pro.eattheblocks.com/p/smart-contract-security-101)
 * [Certified Blockchain Security Professional (CBSP)](https://blockchaintrainingalliance.com/products/cbsp)
 * [Learn blockchain security](https://www.infosecinstitute.com/skills/learning-paths/blockchain-security/)
+
 # Tools
 ### Visualization
 


### PR DESCRIPTION
Hi there, apologies there seemed to have been a mix up in the Links.
SecDim and Ethereum Links under trainings were pointing to the wrong links.
I traced back the original contents from previous commits and patched in the fix.
Sorry for the inconvenience! 