### PR TITLE
Add Sharpe Rug Check to bug hunting tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@
 * [Slither](https://github.com/trailofbits/slither) - Static analysis framework, written in Python, with detectors for many common Solidity issues
 * [Octopus](https://github.com/pventuzelo/octopus) - : Blockchain Smart Contracts (BTC/ETH/NEO/EOS)
 * [L3X](https://github.com/VulnPlanet/l3x) - AI-driven Smart Contract Static Analyzer
+* [Sharpe Rug Check](https://www.sharpe.ai/rug-check) - Token risk scanner for EVM and Solana assets, covering liquidity, holder, ownership, authority, and honeypot signals
 ### Reverse Engineering
 
 * [abi-decompiler](https://github.com/beched/abi-decompiler) - EVM reverse engineering helper utility


### PR DESCRIPTION
Summary
- Adds Sharpe Rug Check under BugHunting.
- Keeps the description short and limited to token risk scanning.

Why this belongs here
The BugHunting section mixes scanners, bounty resources, and tools auditors can use before manual review. Sharpe Rug Check adds a token-focused check for EVM and Solana assets, covering risk signals that are useful when screening suspicious tokens.

Verification
- Checked the Rug Check page on 2026-05-14: https://www.sharpe.ai/rug-check
- Ran git diff --check.
- Searched open and closed PRs and issues for Sharpe before submitting.

Disclosure
I am affiliated with Sharpe.
