### PR TITLE
Add Al-Mizaan Judge to BugHunting

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@
 * [Slither](https://github.com/trailofbits/slither) - Static analysis framework, written in Python, with detectors for many common Solidity issues
 * [Octopus](https://github.com/pventuzelo/octopus) - : Blockchain Smart Contracts (BTC/ETH/NEO/EOS)
 * [L3X](https://github.com/VulnPlanet/l3x) - AI-driven Smart Contract Static Analyzer
+* [Al-Mizaan Judge](https://github.com/holistis/al-mizaan-judge) - CLI that runs a bug bounty finding through an adversarial debate (Defender/Attacker/Judge) before you spend a Sherlock/Immunefi/Cantina submission on it
 ### Runtime Monitoring & Scam Detection
 
 These tools complement static analysis by watching contracts post-deployment for honeypots, rug pulls, and adversarial deployer patterns. Most are free to use.


### PR DESCRIPTION
Adds a CLI tool that runs a bug bounty finding through a strict, adversarial-debate judge before you spend a real submission on Sherlock, Immunefi, or Cantina. Free mechanical gates catch the cheap kills first (trusted-actor-only attacker, unproven oracle economics); the debate handles the harder reasoning (reachability, invariant breach, protocol intent, dollar impact).

- Repo: https://github.com/holistis/al-mizaan-judge
- npm: https://www.npmjs.com/package/al-mizaan-judge

Happy to move it to a different section if you'd prefer — BugHunting looked like the closest existing fit.