### PR TITLE
Add OpenClaw Audit to Tools → BugHunting

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@
 * [Slither](https://github.com/trailofbits/slither) - Static analysis framework, written in Python, with detectors for many common Solidity issues
 * [Octopus](https://github.com/pventuzelo/octopus) - : Blockchain Smart Contracts (BTC/ETH/NEO/EOS)
 * [L3X](https://github.com/VulnPlanet/l3x) - AI-driven Smart Contract Static Analyzer
+* [OpenClaw Audit](https://github.com/juan23z/openclaw-audit) - Heuristic Solidity security scanner calibrated to 0 false positives across all of OpenZeppelin; runs as a GitHub Action.
 ### Runtime Monitoring & Scam Detection
 
 These tools complement static analysis by watching contracts post-deployment for honeypots, rug pulls, and adversarial deployer patterns. Most are free to use.


### PR DESCRIPTION
Adds **OpenClaw Audit**, an open-source (MIT) heuristic Solidity security scanner calibrated to zero false positives across the entire OpenZeppelin library — repo in, professional report out, and it runs as a GitHub Action. Placed under Tools → BugHunting alongside the other static analyzers. Thanks for maintaining this list!