### PR TITLE
Add EVM Smart Audit to BugHunting

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@
 * [Octopus](https://github.com/pventuzelo/octopus) - : Blockchain Smart Contracts (BTC/ETH/NEO/EOS)
 * [L3X](https://github.com/VulnPlanet/l3x) - AI-driven Smart Contract Static Analyzer
 * [Al-Mizaan Judge](https://github.com/holistis/al-mizaan-judge) - CLI that runs a bug bounty finding through an adversarial debate (Defender/Attacker/Judge) before you spend a Sherlock/Immunefi/Cantina submission on it
+* [EVM Smart Audit](https://github.com/evmsmart/solidity-detectors) - Twenty AST-based detectors for Solidity mapped to SWC and the OWASP Smart Contract Top 10; reports the checks that passed as well as the ones that fired. MIT.
 ### Runtime Monitoring & Scam Detection
 
 These tools complement static analysis by watching contracts post-deployment for honeypots, rug pulls, and adversarial deployer patterns. Most are free to use.


### PR DESCRIPTION
Adds **EVM Smart Audit** to the BugHunting section.

It is a suite of 20 AST-based static detectors for Solidity, covering reentrancy,
access control, `tx.origin` authorization, arbitrary `delegatecall`, unchecked
low-level calls, unprotected `selfdestruct`, weak randomness, timestamp
dependence, unchecked arithmetic, floating pragma, shadowed variables, unbounded
loops and four gas patterns.

Every finding is mapped to its SWC Registry id, and results are graded against
both the SWC Registry and the OWASP Smart Contract Top 10. The grading step
reports the checks that **passed** as well as the ones that fired, which is the
part most tools omit — without it you cannot distinguish "checked and clean"
from "never checked".

Licence: MIT. No API keys required; the detector suite runs offline.

Example output against a vault with the balance cleared after an external call:

```
high          SWC-107  Potential reentrancy
high          SWC-115  Authorization via tx.origin
medium        SWC-104  Unchecked send return value
high          SWC-105  Unprotected privileged function `withdraw`
informational SWC-103  Floating pragma
```

Happy to adjust the wording or move it to a different section if BugHunting
isn't the right fit.